### PR TITLE
Try to fix navigate + view-transitions for latest Chrome API changes.

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -17,6 +17,7 @@ const { title } = Astro.props as Props;
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<meta name="generator" content={Astro.generator} />
+		<meta name="view-transition" content="same-origin" />
 		<title>{title}</title>
 		<script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 		<script>

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -22,38 +22,37 @@
   }
 }
 
-::page-transition-outgoing-image(root) {
+::view-transition-old(root) {
   animation: 90ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
     300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left;
 }
 
-::page-transition-incoming-image(root) {
+::view-transition-new(root) {
   animation: 210ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
     300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
 }
 
-::page-transition-outgoing-image(movie-poster),
-::page-transition-incoming-image(movie-poster) {
+::view-transition-pair(movie-poster) {
   animation: none;
   mix-blend-mode: normal;
 }
 
-::page-transition-image-wrapper(movie-poster) {
+::view-transition-group(movie-poster) {
   isolation: none;
 }
 
 .nav {
-  page-transition-tag: main-header;
+  view-transition-name: main-header;
   contain: paint;
 }
 
 .movie-poster {
-  page-transition-tag: movie-poster;
+  view-transition-name: movie-poster;
   contain: paint;
 }
 
 .person-photo {
-  page-transition-tag: person-photo;
+  view-transition-name: person-photo;
   contain: paint;
 }
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -32,7 +32,8 @@
     300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
 }
 
-::view-transition-pair(movie-poster) {
+::view-transition-old(movie-poster),
+::view-transition-new(movie-poster) {
   animation: none;
   mix-blend-mode: normal;
 }

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -38,7 +38,7 @@
   mix-blend-mode: normal;
 }
 
-::view-transition-group(movie-poster) {
+::view-transition-image-pair(movie-poster) {
   isolation: none;
 }
 


### PR DESCRIPTION
It looks like there was already a `modern-navigation-api-handlers.js` file with a note:

> Once 105 reaches GA, the navigation handlers in spa-navigation.js will be replaced with the ones in this file.

Chrome is now m107 in Stable and the old astro movies demo is breaking.  During that time, there seemed to be some changes to the current `spa-navigation.js` so I did my best to integrate.  I wasn't sure of the changes was newer, so worth checking.

---

There have also been API change to view-transitions.  I have gone ahead and tried to update this PR for both changes at once.

View transitions work on Chrome Canary m110, and fail gracefully on the current Stable m107.  Or, you may want to take the changes piecewise (separate the navigation changes from view transition changes).

---

I also started to experiment with Cross-Document vs Same-document transitions... with a simple way to toggle.  Perhaps this is something that should be configurable with cookies to make testing without re-deployment possible.

It would take a bit more effort to actually make the cross-document transitions look equivalent.

---

I can't be sure I got the full Look&Feel of transitions right, but it seems to work well enough for me!

Thank you for building an elegant demo that helps me test Navigation API + View Transitions.